### PR TITLE
Changed codebase to use plain char pointer and arrays instead of std string and vector for improved compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,28 @@
+### PlatformIO
+.pio/
+.pioenvs/
+.piolibdeps/
 
+### Build artifacts
+*.o
+*.a
+*.elf
+*.bin
+*.hex
+*.map
+
+### Logs
+*.log
+
+### OS files
+.DS_Store
+Thumbs.db
+Desktop.ini
+
+### IDE/editor
+.vscode/
+.idea/
+*.code-workspace
+
+### Misc
 .development

--- a/README.md
+++ b/README.md
@@ -1,29 +1,29 @@
 # GuL Plantower
+
 **GuL Plantower** is a library for the Arduino-Framework to work with the plantower particulate matter sensors like PMS7003
-
-
 
 ## Installation
 
 1. [Arduino Library Manager (Recommended)](https://www.arduino.cc/en/Guide/Libraries)  
 2. [Download or clone this repository into your arduino libraries directory](https://help.github.com/articles/cloning-a-repository/)  
 
-
 ## Usage
+
 1. Include module  
-   
+
    ```cpp
    #include <PMS7003.h> // Or one of the other moduls
    ```
-   
+
 2. Create a instance with the serial port it uses
+
 ```cpp
   //The modul uses the namespace GuL, instead of Serial1 you can use Serial, Serial2, or own instantiated HardwareSerial or SoftwareSerial
    GuL::PMS7003 pms(&Serial1); 
 ```
-   
-3. In `setup()`, basic setup of the modul.  
-   
+
+1. In `setup()`, basic setup of the modul.  
+
    ```cpp
    void setup() {
      pms.setToPassiveReporting();
@@ -34,9 +34,9 @@
      pms.sleep();
    }
    ```
-   
-4. In `loop()` of the sketch, run the object's **loop()** method.  
-   
+
+2. In `loop()` of the sketch, run the object's **loop()** method.  
+
    ```cpp
    void loop() {
       // If in passive reporting mode
@@ -51,11 +51,10 @@
       int pm1_std = pms.getPM1_STD();
       int pn1000 = pms.getgetCntBeyond1000nm();
    }
-   ```   
-
-
+   ```
 
 ## APIs
+
 ### Constructors
 
    ```cpp
@@ -65,128 +64,148 @@
 ### methods
 
   ```cpp
-std::string getSensorName() { return _name; }
+const char *getSensorName() { return _name; }
   ```
-  Return the device name (Like PMS7003 or PMSA003)
 
+  Return the device name (Like PMS7003 or PMSA003)
 
   ```cpp
     bool poll();
   ```
+
   Polls the next dataframe from the sensor, the call is only neccessary if the sensor is in passive reporting mode
 
   ```cpp
     virtual bool read();
   ```
+
   Reads the incomming data frame, validates and unpack
 
   ```cpp
     bool sleep();
   ```
+
   Switch the sensor to sleep mode (Saves power consumption)
 
   ```cpp
     bool wakeup();
   ```
+
   Wake the sensor up (also wakes up if there is a poll() call)
 
   ```cpp
     bool setToActiveReporting();
   ```
+
   Like tha name says, set the sensor in active reporting mode, so each second a data frame will be send automatically
 
   ```cpp
     bool setToPassiveReporting();
   ```
+
   Set the sensor in passive reporting mode, each data frame have do be polled
 
   ```cpp
     int getPM1_STD();
   ```
+
   Get the last received PM1 concentration under the assumption of a standarized particle. Returns a negative number if there is no data
 
   ```cpp
     int getPM2_5_STD();
   ```
+
   Get the last received PM2.5 concentration under the assumption of a standarized particle. Returns a negative number if there is no data
 
   ```cpp
     int getPM10_STD();
   ```
+
   Get the last received PM10 concentration under the assumption of a standarized particle. Returns a negative number if there is no data
 
   ```cpp
     int getPM1_ATM();
   ```
-  Get the last received PM1 concentration under the assumption of a athmospheric particle. Returns a negative number if there is no data
 
+  Get the last received PM1 concentration under the assumption of a athmospheric particle. Returns a negative number if there is no data
 
   ```cpp
     int getPM2_5_ATM();
   ```
+
   Get the last received PM2.5 concentration under the assumption of a athmospheric particle. Returns a negative number if there is no data
 
   ```cpp
     int getPM10_ATM();
   ```
+
   Get the last received PM10 concentration under the assumption of a athmospheric particle. Returns a negative number if there is no data
 
   ```cpp
     int getCntBeyond300nm();
   ```
+
   Get the last received number concentration per 0.1 l of particles greater than 300nm. Returns a negative number if there is no data
 
   ```cpp
     int getCntBeyond500nm();
   ```
+
   Get the last received number concentration per 0.1 l of particles greater than 500nm. Returns a negative number if there is no data
 
   ```cpp
     int getCntBeyond1000nm();
   ```
+
   Get the last received number concentration per 0.1 l of particles greater than 1000nm. Returns a negative number if there is no data
 
   ```cpp
     int getCntBeyond2500nm();
   ```
+
   Get the last received number concentration per 0.1 l of particles greater than 2500nm. Returns a negative number if there is no data
 
   ```cpp
     int getCntBeyond5000nm();
   ```
+
   Get the last received number concentration per 0.1 l of particles greater than 5000nm. Returns a negative number if there is no data
 
   ```cpp
     int getCntBeyond10000nm();
   ```
-  Get the last received number concentration per 0.1 l of particles greater than 10.000nm. Returns a negative number if there is no data
 
+  Get the last received number concentration per 0.1 l of particles greater than 10.000nm. Returns a negative number if there is no data
 
   ```cpp
     int getVersion();
   ```
+
   Get the last received sensor firmware version. Returns a negative number if there is no data. (Only newer devices return a version)
 
   ```cpp
     int getError();
   ```
+
   Get the last received error code. Returns a negative number if there is no data. (Only newer devices return a error code)
 
   ```cpp
     float getFormaldehydeConcentration();
   ```
+
   Get the last received formaldehyde concentration in mg/m³. Returns a negative number if there is no data. (At the moment just the PMS5003ST returns this data)
 
   ```cpp
     float getTemperature();
   ```
+
   Get the last received temperature in °C. Returns a negative number if there is no data. (At the moment just the PMS5003ST returns this data)
 
   ```cpp
     float getHumidity();
   ```
-  Get the last received humidity in %. Returns a negative number if there is no data. (At the moment just the PMS5003ST returns this data)
 
+  Get the last received humidity in %. Returns a negative number if there is no data. (At the moment just the PMS5003ST returns this data)
 
 ## What's Next
 

--- a/examples/passive_reading/passive_reading.ino
+++ b/examples/passive_reading/passive_reading.ino
@@ -5,21 +5,6 @@ GuL::PMS7003 pms(Serial2);
 #define RX2 1
 #define TX2 38
 
-std::string outputFormat = "PM1 (STD) \t= % 6d µg/µ3 \n"
-                           "PM2.5 (STD) \t= % 6d µg/µ3 \n"
-                           "PM10 (STD) \t= % 6d µg/µ3 \n"
-                           "PM1 (ATM) \t= % 6d µg/µ3 \n"
-                           "PM2.5 (ATM) \t= % 6d µg/µ3 \n"
-                           "PM10 (ATM) \t= % 6d µg/µ3 \n"
-                           "\n"
-                           "PN300 \t= % 6d #\\0.1 l \n"
-                           "PN500 \t= % 6d #\\0.1 l \n"
-                           "PN1000 \t= % 6d #\\0.1 l \n"
-                           "PN2500 \t= % 6d #\\0.1 l \n"
-                           "PN5000 \t= % 6d #\\0.1 l \n"
-                           "PN1000 \t= % 6d #\\0.1 l \n"
-                           "\n";
-
 void setup()
 {
   Serial.begin(9600);
@@ -35,18 +20,56 @@ void loop()
   delay(20);
   pms.read();
 
-  Serial.printf(outputFormat.c_str(),
-                pms.getPM1_STD(),
-                pms.getPM2_5_STD(),
-                pms.getPM10_STD(),
-                pms.getPM1_ATM(),
-                pms.getPM2_5_ATM(),
-                pms.getPM10_ATM(),
-                pms.getCntBeyond300nm(),
-                pms.getCntBeyond5000nm(),
-                pms.getCntBeyond1000nm(),
-                pms.getCntBeyond2500nm(),
-                pms.getCntBeyond5000nm(),
-                pms.getCntBeyond10000nm());
+  Serial.print("PM1 (STD) \t= ");
+  Serial.print(pms.getPM1_STD());
+  Serial.println(" \xC2\xB5g/\xC2\xB53");
+
+  Serial.print("PM2.5 (STD) \t= ");
+  Serial.print(pms.getPM2_5_STD());
+  Serial.println(" \xC2\xB5g/\xC2\xB53");
+
+  Serial.print("PM10 (STD) \t= ");
+  Serial.print(pms.getPM10_STD());
+  Serial.println(" \xC2\xB5g/\xC2\xB53");
+
+  Serial.print("PM1 (ATM) \t= ");
+  Serial.print(pms.getPM1_ATM());
+  Serial.println(" \xC2\xB5g/\xC2\xB53");
+
+  Serial.print("PM2.5 (ATM) \t= ");
+  Serial.print(pms.getPM2_5_ATM());
+  Serial.println(" \xC2\xB5g/\xC2\xB53");
+
+  Serial.print("PM10 (ATM) \t= ");
+  Serial.print(pms.getPM10_ATM());
+  Serial.println(" \xC2\xB5g/\xC2\xB53");
+
+  Serial.println();
+
+  Serial.print("PN300 \t= ");
+  Serial.print(pms.getCntBeyond300nm());
+  Serial.println(" #\\0.1 l");
+
+  Serial.print("PN500 \t= ");
+  Serial.print(pms.getCntBeyond5000nm());
+  Serial.println(" #\\0.1 l");
+
+  Serial.print("PN1000 \t= ");
+  Serial.print(pms.getCntBeyond1000nm());
+  Serial.println(" #\\0.1 l");
+
+  Serial.print("PN2500 \t= ");
+  Serial.print(pms.getCntBeyond2500nm());
+  Serial.println(" #\\0.1 l");
+
+  Serial.print("PN5000 \t= ");
+  Serial.print(pms.getCntBeyond5000nm());
+  Serial.println(" #\\0.1 l");
+
+  Serial.print("PN1000 \t= ");
+  Serial.print(pms.getCntBeyond10000nm());
+  Serial.println(" #\\0.1 l");
+
+  Serial.println();
   delay(1000);
 }

--- a/platformio.ini
+++ b/platformio.ini
@@ -16,3 +16,9 @@ description="Library for the arduino framework for handling the particle sensor 
 platform = espressif32
 board = esp-wrover-kit
 framework = arduino
+
+[env:native]
+platform = native
+test_framework = unity
+build_flags = -I test/arduino_shim
+test_build_src = yes

--- a/src/Plantower.h
+++ b/src/Plantower.h
@@ -26,7 +26,6 @@
  */
 
 #include <Arduino.h>
-#include <vector>
 
 #ifndef GUL_PLANTOWER_PLANTOWER_H
 #define GUL_PLANTOWER_PLANTOWER_H
@@ -58,7 +57,7 @@ namespace GuL
   {
   public:
     Plantower(Stream &stream);
-    std::string getSensorName() { return _name; }
+    const char *getSensorName() { return _name; }
 
     bool poll();
     virtual bool read();
@@ -123,17 +122,21 @@ namespace GuL
       HUMIDITY_IDX,
       CNT_OF_CHANNELS
     };
-    std::string _name = "PLANTOWER";
-    std::vector<uint8_t> _payloadBuffer;
-    size_t _bufferLength;
+    static const size_t MAX_FRAME_LENGTH = 28;
+    static const size_t PAYLOAD_HEADER_LENGTH = 4;
+    static const size_t MAX_PAYLOAD_LENGTH = MAX_FRAME_LENGTH + PAYLOAD_HEADER_LENGTH;
+
+    const char *_name = "PLANTOWER";
+    uint8_t _payloadBuffer[MAX_PAYLOAD_LENGTH];
+    size_t _payloadBufferLength = 0;
     uint16_t _frameLength = 0;
     int _activeFrameLength = -1;
     int32_t *_data = nullptr;
     Plantower_Working_Mode _workMode = Plantower_Working_Mode::WAKEUP;
     Plantower_Reporting_Mode _reportingMode = Plantower_Reporting_Mode::ACTIVE;
 
-    uint16_t calcChecksum(std::vector<uint8_t> cmd, size_t cnt);
-    virtual bool sendFrame(std::vector<uint8_t> cmd);
+    uint16_t calcChecksum(const uint8_t *cmd, size_t cnt);
+    virtual bool sendFrame(uint8_t *cmd, size_t cnt);
     virtual void unpackPayload();
     void unpackBasePMData();
     void unpackBasePNData();

--- a/test/arduino_shim/Arduino.h
+++ b/test/arduino_shim/Arduino.h
@@ -1,0 +1,38 @@
+#ifndef GUL_PLANTOWER_TEST_ARDUINO_H
+#define GUL_PLANTOWER_TEST_ARDUINO_H
+
+#include <cstddef>
+#include <cstdint>
+
+using size_t = std::size_t;
+using uint8_t = std::uint8_t;
+using uint16_t = std::uint16_t;
+using int32_t = std::int32_t;
+
+class Print
+{
+public:
+    virtual ~Print() {}
+    virtual size_t write(uint8_t value) = 0;
+    virtual size_t write(const uint8_t *buffer, size_t size)
+    {
+        size_t written = 0;
+        for (size_t i = 0; i < size; i++)
+        {
+            written += write(buffer[i]);
+        }
+        return written;
+    }
+};
+
+class Stream : public Print
+{
+public:
+    virtual ~Stream() {}
+    virtual int available() = 0;
+    virtual int read() = 0;
+    virtual int peek() = 0;
+    virtual size_t write(const uint8_t *buffer, size_t size) = 0;
+};
+
+#endif

--- a/test/plantower_native/test_plantower.cpp
+++ b/test/plantower_native/test_plantower.cpp
@@ -1,0 +1,249 @@
+#include <unity.h>
+#include "Plantower.h"
+
+class FakeStream : public Stream
+{
+public:
+    FakeStream(const uint8_t *data, size_t len)
+    {
+        inputLen = len > sizeof(input) ? sizeof(input) : len;
+        for (size_t i = 0; i < inputLen; i++)
+        {
+            input[i] = data[i];
+        }
+        inputPos = 0;
+        outputLen = 0;
+    }
+
+    int available() override
+    {
+        return (inputPos < inputLen) ? (int)(inputLen - inputPos) : 0;
+    }
+
+    int read() override
+    {
+        if (inputPos >= inputLen)
+        {
+            return -1;
+        }
+        return input[inputPos++];
+    }
+
+    int peek() override
+    {
+        if (inputPos >= inputLen)
+        {
+            return -1;
+        }
+        return input[inputPos];
+    }
+
+    size_t write(uint8_t value) override
+    {
+        if (outputLen < sizeof(output))
+        {
+            output[outputLen++] = value;
+        }
+        return 1;
+    }
+
+    size_t write(const uint8_t *buffer, size_t size) override
+    {
+        outputLen = size > sizeof(output) ? sizeof(output) : size;
+        for (size_t i = 0; i < outputLen; i++)
+        {
+            output[i] = buffer[i];
+        }
+        return size;
+    }
+
+    const uint8_t *getOutput() const { return output; }
+    size_t getOutputLen() const { return outputLen; }
+
+private:
+    uint8_t input[64];
+    size_t inputLen;
+    size_t inputPos;
+
+    uint8_t output[64];
+    size_t outputLen;
+};
+
+static void setWord(uint8_t *buffer, size_t index, uint16_t value)
+{
+    buffer[index] = (value >> 8) & 0xFF;
+    buffer[index + 1] = value & 0xFF;
+}
+
+static void buildFrame(uint8_t *frame, size_t frameLen)
+{
+    for (size_t i = 0; i < frameLen; i++)
+    {
+        frame[i] = 0;
+    }
+
+    frame[0] = 0x42;
+    frame[1] = 0x4D;
+    frame[2] = 0x00;
+    frame[3] = 0x1C; // 28 bytes
+
+    setWord(frame, 4, 12);   // PM1_STD
+    setWord(frame, 6, 34);   // PM2_5_STD
+    setWord(frame, 8, 56);   // PM10_STD
+    setWord(frame, 10, 78);  // PM1_ATM
+    setWord(frame, 12, 90);  // PM2_5_ATM
+    setWord(frame, 14, 123); // PM10_ATM
+
+    setWord(frame, 16, 1000); // PN300
+    setWord(frame, 18, 2000); // PN500
+    setWord(frame, 20, 3000); // PN1000
+    setWord(frame, 22, 4000); // PN2500
+    setWord(frame, 24, 5000); // PN5000
+    setWord(frame, 26, 6000); // PN10000
+
+    setWord(frame, 28, 0); // unused/reserved
+
+    uint16_t sum = 0;
+    for (size_t i = 0; i < frameLen - 2; i++)
+    {
+        sum += frame[i];
+    }
+    frame[frameLen - 2] = (sum >> 8) & 0xFF;
+    frame[frameLen - 1] = sum & 0xFF;
+}
+
+static void buildFrameShort(uint8_t *frame, size_t frameLen)
+{
+    for (size_t i = 0; i < frameLen; i++)
+    {
+        frame[i] = 0;
+    }
+
+    frame[0] = 0x42;
+    frame[1] = 0x4D;
+    frame[2] = 0x00;
+    frame[3] = 0x14; // 20 bytes
+
+    setWord(frame, 4, 12);   // PM1_STD
+    setWord(frame, 6, 34);   // PM2_5_STD
+    setWord(frame, 8, 56);   // PM10_STD
+    setWord(frame, 10, 78);  // PM1_ATM
+    setWord(frame, 12, 90);  // PM2_5_ATM
+    setWord(frame, 14, 123); // PM10_ATM
+
+    uint16_t sum = 0;
+    for (size_t i = 0; i < frameLen - 2; i++)
+    {
+        sum += frame[i];
+    }
+    frame[frameLen - 2] = (sum >> 8) & 0xFF;
+    frame[frameLen - 1] = sum & 0xFF;
+}
+
+void test_read_parses_frame()
+{
+    uint8_t frame[32];
+    buildFrame(frame, sizeof(frame));
+
+    FakeStream stream(frame, sizeof(frame));
+    GuL::Plantower plantower(stream);
+
+    TEST_ASSERT_TRUE(plantower.read());
+    TEST_ASSERT_EQUAL(12, plantower.getPM1_STD());
+    TEST_ASSERT_EQUAL(34, plantower.getPM2_5_STD());
+    TEST_ASSERT_EQUAL(56, plantower.getPM10_STD());
+    TEST_ASSERT_EQUAL(78, plantower.getPM1_ATM());
+    TEST_ASSERT_EQUAL(90, plantower.getPM2_5_ATM());
+    TEST_ASSERT_EQUAL(123, plantower.getPM10_ATM());
+    TEST_ASSERT_EQUAL(1000, plantower.getCntBeyond300nm());
+    TEST_ASSERT_EQUAL(2000, plantower.getCntBeyond500nm());
+    TEST_ASSERT_EQUAL(3000, plantower.getCntBeyond1000nm());
+    TEST_ASSERT_EQUAL(4000, plantower.getCntBeyond2500nm());
+    TEST_ASSERT_EQUAL(5000, plantower.getCntBeyond5000nm());
+    TEST_ASSERT_EQUAL(6000, plantower.getCntBeyond10000nm());
+}
+
+void test_poll_writes_checksum()
+{
+    uint8_t empty[1] = {0};
+    FakeStream stream(empty, 0);
+    GuL::Plantower plantower(stream);
+
+    TEST_ASSERT_TRUE(plantower.poll());
+    TEST_ASSERT_EQUAL(7, stream.getOutputLen());
+    const uint8_t *out = stream.getOutput();
+    TEST_ASSERT_EQUAL_HEX8(0x42, out[0]);
+    TEST_ASSERT_EQUAL_HEX8(0x4D, out[1]);
+    TEST_ASSERT_EQUAL_HEX8(0xE2, out[2]);
+    TEST_ASSERT_EQUAL_HEX8(0x00, out[3]);
+    TEST_ASSERT_EQUAL_HEX8(0x00, out[4]);
+    TEST_ASSERT_EQUAL_HEX8(0x01, out[5]);
+    TEST_ASSERT_EQUAL_HEX8(0x71, out[6]);
+}
+
+void test_read_rejects_bad_checksum()
+{
+    uint8_t frame[32];
+    buildFrame(frame, sizeof(frame));
+    frame[31] ^= 0xFF;
+
+    FakeStream stream(frame, sizeof(frame));
+    GuL::Plantower plantower(stream);
+
+    TEST_ASSERT_FALSE(plantower.read());
+}
+
+void test_read_skips_garbage_before_frame()
+{
+    uint8_t frame[32];
+    buildFrame(frame, sizeof(frame));
+
+    uint8_t buffer[35];
+    buffer[0] = 0x10;
+    buffer[1] = 0x20;
+    buffer[2] = 0x30;
+    for (size_t i = 0; i < sizeof(frame); i++)
+    {
+        buffer[i + 3] = frame[i];
+    }
+
+    FakeStream stream(buffer, sizeof(buffer));
+    GuL::Plantower plantower(stream);
+
+    TEST_ASSERT_TRUE(plantower.read());
+    TEST_ASSERT_EQUAL(12, plantower.getPM1_STD());
+}
+
+void test_read_length20_parses_base_pm_only()
+{
+    uint8_t frame[24];
+    buildFrameShort(frame, sizeof(frame));
+
+    FakeStream stream(frame, sizeof(frame));
+    GuL::Plantower plantower(stream);
+
+    TEST_ASSERT_TRUE(plantower.read());
+    TEST_ASSERT_EQUAL(12, plantower.getPM1_STD());
+    TEST_ASSERT_EQUAL(34, plantower.getPM2_5_STD());
+    TEST_ASSERT_EQUAL(56, plantower.getPM10_STD());
+    TEST_ASSERT_EQUAL(-1, plantower.getCntBeyond300nm());
+    TEST_ASSERT_EQUAL(-1, plantower.getCntBeyond500nm());
+    TEST_ASSERT_EQUAL(-1, plantower.getCntBeyond1000nm());
+    TEST_ASSERT_EQUAL(-1, plantower.getCntBeyond2500nm());
+    TEST_ASSERT_EQUAL(-1, plantower.getCntBeyond5000nm());
+    TEST_ASSERT_EQUAL(-1, plantower.getCntBeyond10000nm());
+}
+
+void setUp() {}
+void tearDown() {}
+
+int main(int argc, char **argv)
+{
+    UNITY_BEGIN();
+    RUN_TEST(test_read_parses_frame);
+    RUN_TEST(test_poll_writes_checksum);
+    RUN_TEST(test_read_rejects_bad_checksum);
+    RUN_TEST(test_read_skips_garbage_before_frame);
+    RUN_TEST(test_read_length20_parses_base_pm_only);
+    return UNITY_END();
+}

--- a/test/test_plantower.cpp
+++ b/test/test_plantower.cpp
@@ -1,0 +1,263 @@
+#include <unity.h>
+#include <Plantower.h>
+
+class FakeStream : public Stream
+{
+public:
+    FakeStream(const uint8_t *data, size_t length)
+        : _data(data), _length(length), _index(0), _outputLen(0)
+    {
+    }
+
+    int available() override
+    {
+        return (_index < _length) ? (int)(_length - _index) : 0;
+    }
+
+    int read() override
+    {
+        if (_index >= _length)
+        {
+            return -1;
+        }
+        return _data[_index++];
+    }
+
+    int peek() override
+    {
+        if (_index >= _length)
+        {
+            return -1;
+        }
+        return _data[_index];
+    }
+
+    size_t write(uint8_t value) override
+    {
+        if (_outputLen < sizeof(_output))
+        {
+            _output[_outputLen++] = value;
+        }
+        return 1;
+    }
+
+    size_t write(const uint8_t *buffer, size_t size) override
+    {
+        _outputLen = (size > sizeof(_output)) ? sizeof(_output) : size;
+        for (size_t i = 0; i < _outputLen; i++)
+        {
+            _output[i] = buffer[i];
+        }
+        return size;
+    }
+
+    const uint8_t *getOutput() const { return _output; }
+    size_t getOutputLen() const { return _outputLen; }
+
+private:
+    const uint8_t *_data;
+    size_t _length;
+    size_t _index;
+    uint8_t _output[64];
+    size_t _outputLen;
+};
+
+static uint16_t calcChecksum(const uint8_t *data, size_t count)
+{
+    uint16_t sum = 0;
+    for (size_t i = 0; i < count; i++)
+    {
+        sum += data[i];
+    }
+    return sum;
+}
+
+static void buildFrame(uint8_t *frame, size_t frameLength)
+{
+    const size_t payloadLength = frameLength + 4;
+    for (size_t i = 0; i < payloadLength; i++)
+    {
+        frame[i] = 0;
+    }
+
+    frame[0] = 0x42;
+    frame[1] = 0x4D;
+    frame[2] = (uint8_t)((frameLength >> 8) & 0xFF);
+    frame[3] = (uint8_t)(frameLength & 0xFF);
+
+    // Base PM values
+    const uint16_t pm1_std = 11;
+    const uint16_t pm2_5_std = 22;
+    const uint16_t pm10_std = 33;
+    const uint16_t pm1_atm = 44;
+    const uint16_t pm2_5_atm = 55;
+    const uint16_t pm10_atm = 66;
+
+    // Base PN values
+    const uint16_t pn300 = 77;
+    const uint16_t pn500 = 88;
+    const uint16_t pn1000 = 99;
+    const uint16_t pn2500 = 111;
+    const uint16_t pn5000 = 122;
+    const uint16_t pn10000 = 133;
+
+    frame[4] = (uint8_t)(pm1_std >> 8);
+    frame[5] = (uint8_t)(pm1_std & 0xFF);
+    frame[6] = (uint8_t)(pm2_5_std >> 8);
+    frame[7] = (uint8_t)(pm2_5_std & 0xFF);
+    frame[8] = (uint8_t)(pm10_std >> 8);
+    frame[9] = (uint8_t)(pm10_std & 0xFF);
+    frame[10] = (uint8_t)(pm1_atm >> 8);
+    frame[11] = (uint8_t)(pm1_atm & 0xFF);
+    frame[12] = (uint8_t)(pm2_5_atm >> 8);
+    frame[13] = (uint8_t)(pm2_5_atm & 0xFF);
+    frame[14] = (uint8_t)(pm10_atm >> 8);
+    frame[15] = (uint8_t)(pm10_atm & 0xFF);
+
+    if (frameLength >= 28)
+    {
+        frame[16] = (uint8_t)(pn300 >> 8);
+        frame[17] = (uint8_t)(pn300 & 0xFF);
+        frame[18] = (uint8_t)(pn500 >> 8);
+        frame[19] = (uint8_t)(pn500 & 0xFF);
+        frame[20] = (uint8_t)(pn1000 >> 8);
+        frame[21] = (uint8_t)(pn1000 & 0xFF);
+        frame[22] = (uint8_t)(pn2500 >> 8);
+        frame[23] = (uint8_t)(pn2500 & 0xFF);
+        frame[24] = (uint8_t)(pn5000 >> 8);
+        frame[25] = (uint8_t)(pn5000 & 0xFF);
+        frame[26] = (uint8_t)(pn10000 >> 8);
+        frame[27] = (uint8_t)(pn10000 & 0xFF);
+
+        // Version & error (not unpacked by library, but part of payload)
+        frame[28] = 0x00;
+        frame[29] = 0x00;
+    }
+
+    const uint16_t checksum = calcChecksum(frame, payloadLength - 2);
+    frame[payloadLength - 2] = (uint8_t)((checksum >> 8) & 0xFF);
+    frame[payloadLength - 1] = (uint8_t)(checksum & 0xFF);
+}
+
+void test_read_frame_parses_values()
+{
+    const size_t frameLength = 28;
+    uint8_t frame[frameLength + 4];
+    buildFrame(frame, frameLength);
+
+    FakeStream stream(frame, sizeof(frame));
+    GuL::Plantower sensor(stream);
+
+    bool gotFrame = false;
+    for (int i = 0; i < 10; i++)
+    {
+        if (sensor.read())
+        {
+            gotFrame = true;
+            break;
+        }
+    }
+
+    TEST_ASSERT_TRUE(gotFrame);
+    TEST_ASSERT_EQUAL(11, sensor.getPM1_STD());
+    TEST_ASSERT_EQUAL(22, sensor.getPM2_5_STD());
+    TEST_ASSERT_EQUAL(33, sensor.getPM10_STD());
+    TEST_ASSERT_EQUAL(44, sensor.getPM1_ATM());
+    TEST_ASSERT_EQUAL(55, sensor.getPM2_5_ATM());
+    TEST_ASSERT_EQUAL(66, sensor.getPM10_ATM());
+    TEST_ASSERT_EQUAL(77, sensor.getCntBeyond300nm());
+    TEST_ASSERT_EQUAL(88, sensor.getCntBeyond500nm());
+    TEST_ASSERT_EQUAL(99, sensor.getCntBeyond1000nm());
+    TEST_ASSERT_EQUAL(111, sensor.getCntBeyond2500nm());
+    TEST_ASSERT_EQUAL(122, sensor.getCntBeyond5000nm());
+    TEST_ASSERT_EQUAL(133, sensor.getCntBeyond10000nm());
+}
+
+void test_read_rejects_bad_checksum()
+{
+    const size_t frameLength = 28;
+    uint8_t frame[frameLength + 4];
+    buildFrame(frame, frameLength);
+
+    frame[frameLength + 3] ^= 0xFF;
+
+    FakeStream stream(frame, sizeof(frame));
+    GuL::Plantower sensor(stream);
+
+    TEST_ASSERT_FALSE(sensor.read());
+}
+
+void test_read_skips_garbage_before_frame()
+{
+    const size_t frameLength = 28;
+    uint8_t frame[frameLength + 4];
+    buildFrame(frame, frameLength);
+
+    uint8_t buffer[frameLength + 7];
+    buffer[0] = 0x00;
+    buffer[1] = 0x11;
+    buffer[2] = 0x22;
+    for (size_t i = 0; i < sizeof(frame); i++)
+    {
+        buffer[i + 3] = frame[i];
+    }
+
+    FakeStream stream(buffer, sizeof(buffer));
+    GuL::Plantower sensor(stream);
+
+    TEST_ASSERT_TRUE(sensor.read());
+    TEST_ASSERT_EQUAL(11, sensor.getPM1_STD());
+}
+
+void test_read_length20_parses_base_pm_only()
+{
+    const size_t frameLength = 20;
+    uint8_t frame[frameLength + 4];
+    buildFrame(frame, frameLength);
+
+    FakeStream stream(frame, sizeof(frame));
+    GuL::Plantower sensor(stream);
+
+    TEST_ASSERT_TRUE(sensor.read());
+    TEST_ASSERT_EQUAL(11, sensor.getPM1_STD());
+    TEST_ASSERT_EQUAL(22, sensor.getPM2_5_STD());
+    TEST_ASSERT_EQUAL(33, sensor.getPM10_STD());
+    TEST_ASSERT_EQUAL(-1, sensor.getCntBeyond300nm());
+    TEST_ASSERT_EQUAL(-1, sensor.getCntBeyond500nm());
+    TEST_ASSERT_EQUAL(-1, sensor.getCntBeyond1000nm());
+    TEST_ASSERT_EQUAL(-1, sensor.getCntBeyond2500nm());
+    TEST_ASSERT_EQUAL(-1, sensor.getCntBeyond5000nm());
+    TEST_ASSERT_EQUAL(-1, sensor.getCntBeyond10000nm());
+}
+
+void test_poll_writes_checksum()
+{
+    uint8_t empty[1] = {0};
+    FakeStream stream(empty, 0);
+    GuL::Plantower sensor(stream);
+
+    TEST_ASSERT_TRUE(sensor.poll());
+    TEST_ASSERT_EQUAL(7, stream.getOutputLen());
+    const uint8_t *out = stream.getOutput();
+    TEST_ASSERT_EQUAL_HEX8(0x42, out[0]);
+    TEST_ASSERT_EQUAL_HEX8(0x4D, out[1]);
+    TEST_ASSERT_EQUAL_HEX8(0xE2, out[2]);
+    TEST_ASSERT_EQUAL_HEX8(0x00, out[3]);
+    TEST_ASSERT_EQUAL_HEX8(0x00, out[4]);
+    TEST_ASSERT_EQUAL_HEX8(0x01, out[5]);
+    TEST_ASSERT_EQUAL_HEX8(0x71, out[6]);
+}
+
+void setUp() {}
+void tearDown() {}
+
+int main(int argc, char **argv)
+{
+    UNITY_BEGIN();
+    RUN_TEST(test_read_frame_parses_values);
+    RUN_TEST(test_read_rejects_bad_checksum);
+    RUN_TEST(test_read_skips_garbage_before_frame);
+    RUN_TEST(test_read_length20_parses_base_pm_only);
+    RUN_TEST(test_poll_writes_checksum);
+    return UNITY_END();
+}


### PR DESCRIPTION
The formal use of std::string and std::vector limited compatibility, so now we are switching to plain char pointers and arrays.
See also issue #3 