### PR TITLE
Fail reason reporting

### DIFF
--- a/src/Plantower.cpp
+++ b/src/Plantower.cpp
@@ -90,8 +90,10 @@ namespace GuL
 
     bool Plantower::read()
     {
+        _lastFailureReason = NO_FAILURE;
         if (_uart == nullptr || _uart->available() == 0)
         {
+            _lastFailureReason = NO_BYTES_AVAILABLE;
             return false; // No data available
         }
 
@@ -124,6 +126,7 @@ namespace GuL
 
                 if (!this->expectedFrameLength(_frameLength))
                 {
+                    _lastFailureReason = INVALID_FRAME_LENGTH;
                     _parseStep = WAIT_FOR_NEW_FRAME;
                     break;
                 }
@@ -140,6 +143,10 @@ namespace GuL
                         this->unpackPayload();
                         _gotValidFrame = true;
                     }
+                    else
+                    {
+                        _lastFailureReason = CHECKSUM_FAILURE;
+                    }
                     _parseStep = WAIT_FOR_NEW_FRAME;
                 }
                 break;
@@ -150,6 +157,10 @@ namespace GuL
         {
             _gotValidFrame = false;
             return true;
+        }
+        if (_lastFailureReason == NO_FAILURE)
+        {
+            _lastFailureReason = INCOMPLETE_FRAME;
         }
         return false;
     }
@@ -176,6 +187,10 @@ namespace GuL
         cmd[cnt - 1] = checksum & 0xFF;
 
         size_t bytesSend = _uart ? _uart->write(cmd, cnt) : 0;
+        if (bytesSend != cnt)
+        {
+            _lastFailureReason = UART_WRITE_FAILURE;
+        }
         return bytesSend == cnt;
     }
 
@@ -198,6 +213,7 @@ namespace GuL
         if (_payloadBufferLength > MAX_PAYLOAD_LENGTH)
         {
             _payloadBufferLength = 0;
+            _lastFailureReason = INVALID_FRAME_LENGTH;
             _parseStep = WAIT_FOR_NEW_FRAME;
             return;
         }
@@ -213,6 +229,7 @@ namespace GuL
     {
         if (_payloadBufferLength < 2)
         {
+            _lastFailureReason = NO_BYTES_AVAILABLE;
             return false;
         }
         uint16_t calcCS = this->calcChecksum(_payloadBuffer, _payloadBufferLength - 2);

--- a/src/Plantower.h
+++ b/src/Plantower.h
@@ -60,6 +60,17 @@ namespace GuL
   class Plantower
   {
   public:
+    enum FailureReason
+    {
+      NO_FAILURE = 0,
+      CHECKSUM_FAILURE,
+      INVALID_FRAME_LENGTH,
+      UART_WRITE_FAILURE,
+      INCOMPLETE_FRAME,
+      NO_BYTES_AVAILABLE,
+      MISSING_BYTES
+    };
+
     Plantower(UARTInterface &uart);
 #ifdef ARDUINO
     Plantower(HardwareSerial &stream);
@@ -95,6 +106,8 @@ namespace GuL
     float getFormaldehydeConcentration();
     float getTemperature();
     float getHumidity();
+
+    FailureReason getLastFailureReason() { return _lastFailureReason; }
 
   private:
     void init();
@@ -147,6 +160,7 @@ namespace GuL
     int32_t _data[CNT_OF_CHANNELS];
     Plantower_Working_Mode _workMode = Plantower_Working_Mode::WAKEUP;
     Plantower_Reporting_Mode _reportingMode = Plantower_Reporting_Mode::ACTIVE;
+    FailureReason _lastFailureReason = NO_FAILURE;
 
     static uint16_t calcChecksum(const uint8_t *cmd, size_t cnt);
     virtual bool sendFrame(uint8_t *cmd, size_t cnt);

--- a/test/mock/MockUartInterface.h
+++ b/test/mock/MockUartInterface.h
@@ -8,9 +8,11 @@ public:
     int available() override { return (int)(readBufferLen - readBufferIndex); }
     int peek() override { return (readBufferIndex < readBufferLen) ? readBuffer[readBufferIndex] : -1; }
     int read() override { return (readBufferIndex < readBufferLen) ? readBuffer[readBufferIndex++] : -1; }
-    size_t write(uint8_t byte) override { return (outputLen < sizeof(output)) ? (output[outputLen++] = byte, 1) : 0; }
+    size_t write(uint8_t byte) override { return writeEnable && (outputLen < sizeof(output)) ? (output[outputLen++] = byte, 1) : 0; }
     size_t write(const uint8_t *buffer, size_t size) override
     {
+        if (!writeEnable)
+            return 0;
         size_t copyLen = (size + outputLen <= sizeof(output)) ? size : (sizeof(output) - outputLen);
         for (size_t i = 0; i < copyLen; i++)
         {
@@ -21,23 +23,35 @@ public:
     }
     const uint8_t *getOutput() const { return output; }
     size_t getOutputLen() const { return outputLen; }
-    void writeToReadBuffer(const uint8_t *data, size_t len)
+    void appendToInput(const uint8_t *data, size_t len)
     {
-        size_t copyLen = (len + readBufferWriteIndex < sizeof(readBuffer)) ? len : sizeof(readBuffer) - readBufferWriteIndex;
+        size_t copyLen = (len + readBufferLen <= sizeof(readBuffer)) ? len : (sizeof(readBuffer) - readBufferLen);
         for (size_t i = 0; i < copyLen; i++)
         {
-            readBuffer[i + readBufferWriteIndex] = data[i];
+            readBuffer[readBufferLen + i] = data[i];
         }
-        readBufferWriteIndex += copyLen;
-        readBufferLen = readBufferWriteIndex;
-        readBufferIndex = 0;
+        readBufferLen += copyLen; // Update the length of valid data in the buffer
     }
+    void setInput(const uint8_t *data, size_t len)
+    {
+        size_t copyLen = (len <= sizeof(readBuffer)) ? len : (sizeof(readBuffer));
+        for (size_t i = 0; i < copyLen; i++)
+        {
+            readBuffer[i] = data[i];
+        }
+        readBufferLen = copyLen; // Set the length of valid data in the buffer
+        readBufferIndex = 0;     // Reset index to start of buffer for reading
+    }
+
+    void enableWrites() { writeEnable = true; }
+    void disableWrites() { writeEnable = false; }
 
 private:
     uint8_t readBuffer[128];
-    size_t readBufferWriteIndex = 0;
     size_t readBufferLen = 0;
     size_t readBufferIndex = 0;
     uint8_t output[128];
     size_t outputLen = 0;
+
+    bool writeEnable = true;
 };

--- a/test/test_plantower_mock/test_plantower.cpp
+++ b/test/test_plantower_mock/test_plantower.cpp
@@ -87,7 +87,7 @@ void test_read_frame_parses_values()
     buildFrame(frame, frameLength);
 
     MockUartInterface stream;
-    stream.writeToReadBuffer(frame, sizeof(frame));
+    stream.setInput(frame, sizeof(frame));
     GuL::Plantower sensor(stream);
 
     bool gotFrame = false;
@@ -124,7 +124,7 @@ void test_read_rejects_bad_checksum()
     frame[frameLength + 3] ^= 0xFF;
 
     MockUartInterface stream;
-    stream.writeToReadBuffer(frame, sizeof(frame));
+    stream.setInput(frame, sizeof(frame));
     GuL::Plantower sensor(stream);
 
     TEST_ASSERT_FALSE(sensor.read());
@@ -146,7 +146,7 @@ void test_read_skips_garbage_before_frame()
     }
 
     MockUartInterface stream;
-    stream.writeToReadBuffer(buffer, sizeof(buffer));
+    stream.setInput(buffer, sizeof(buffer));
     GuL::Plantower sensor(stream);
 
     TEST_ASSERT_TRUE(sensor.read());
@@ -160,7 +160,7 @@ void test_read_length20_parses_base_pm_only()
     buildFrame(frame, frameLength);
 
     MockUartInterface stream;
-    stream.writeToReadBuffer(frame, sizeof(frame));
+    stream.setInput(frame, sizeof(frame));
     GuL::Plantower sensor(stream);
 
     TEST_ASSERT_TRUE(sensor.read());
@@ -219,6 +219,95 @@ void test_checksum_calculation()
     TEST_ASSERT_EQUAL_HEX16(0xFF0, checksum);
 }
 
+void test_failure_states_are_set()
+{
+    MockUartInterface stream;
+    GuL::Plantower sensor(stream);
+
+    // No data available
+    TEST_ASSERT_FALSE(sensor.read());
+    TEST_ASSERT_EQUAL(GuL::Plantower::NO_BYTES_AVAILABLE, sensor.getLastFailureReason());
+
+    // Bad checksum
+    uint8_t frame[32];
+    buildFrame(frame, 28);
+    frame[30] ^= 0xFF;
+    stream.setInput(frame, sizeof(frame));
+    TEST_ASSERT_FALSE(sensor.read());
+    TEST_ASSERT_EQUAL(GuL::Plantower::CHECKSUM_FAILURE, sensor.getLastFailureReason());
+
+    // Invalid frame length
+    uint8_t badFrame[32];
+    buildFrame(badFrame, 32);
+    badFrame[2] = 0x00; // High byte of length
+    badFrame[3] = 0x00; // And low byte of length, making it 0 - which is unexpected for a valid frame
+    stream.setInput(badFrame, sizeof(badFrame));
+    TEST_ASSERT_FALSE(sensor.read());
+    TEST_ASSERT_EQUAL(GuL::Plantower::INVALID_FRAME_LENGTH, sensor.getLastFailureReason());
+
+    // UART write failure
+    stream.setInput(frame, sizeof(frame));
+    stream.disableWrites();
+    TEST_ASSERT_FALSE(sensor.poll());
+    TEST_ASSERT_EQUAL(GuL::Plantower::UART_WRITE_FAILURE, sensor.getLastFailureReason());
+    stream.enableWrites();
+
+    // Incomplete frame
+    uint8_t incompleteFrame[3];
+    incompleteFrame[0] = 0x42;
+    incompleteFrame[1] = 0x4D;
+    incompleteFrame[2] = 0x00;
+    stream.setInput(incompleteFrame, sizeof(incompleteFrame));
+
+    TEST_ASSERT_FALSE(sensor.read());
+    TEST_ASSERT_EQUAL(GuL::Plantower::INCOMPLETE_FRAME, sensor.getLastFailureReason());
+
+    // Missing bytes (payload length exceeds buffer)
+    uint8_t longFrame[40];
+    buildFrame(longFrame, 36);
+    stream.setInput(longFrame, sizeof(longFrame));
+    TEST_ASSERT_FALSE(sensor.read());
+    TEST_ASSERT_EQUAL(GuL::Plantower::INVALID_FRAME_LENGTH, sensor.getLastFailureReason());
+}
+
+void test_read_proceeds_after_incomplete_frame()
+{
+    uint8_t buffer[40];
+    const size_t frameLength = 28;
+    buildFrame(buffer, frameLength);
+
+    MockUartInterface stream;
+    // First provide an incomplete frame (only first header byte)
+    stream.setInput(buffer, 1);
+
+    GuL::Plantower sensor(stream);
+    TEST_ASSERT_FALSE(sensor.read());
+    TEST_ASSERT_EQUAL(GuL::Plantower::INCOMPLETE_FRAME, sensor.getLastFailureReason());
+    stream.appendToInput(buffer + 1, 1); // Now append the next byte
+    TEST_ASSERT_FALSE(sensor.read());
+    TEST_ASSERT_EQUAL(GuL::Plantower::INCOMPLETE_FRAME, sensor.getLastFailureReason());
+    stream.appendToInput(buffer + 2, 1); // Now append the length high byte
+    TEST_ASSERT_FALSE(sensor.read());
+    TEST_ASSERT_EQUAL(GuL::Plantower::INCOMPLETE_FRAME, sensor.getLastFailureReason());
+    stream.appendToInput(buffer + 3, 1); // Now append the length low byte
+    TEST_ASSERT_FALSE(sensor.read());
+    TEST_ASSERT_EQUAL(GuL::Plantower::INCOMPLETE_FRAME, sensor.getLastFailureReason());
+    // Now each payload byte without the checksum
+    for (size_t i = 4; i < frameLength + 2; i++)
+    {
+        stream.appendToInput(buffer + i, 1);
+        TEST_ASSERT_FALSE(sensor.read());
+        TEST_ASSERT_EQUAL(GuL::Plantower::INCOMPLETE_FRAME, sensor.getLastFailureReason());
+    }
+    // Finally append the checksum bytes one by one
+    stream.appendToInput(buffer + frameLength + 2, 1);
+    TEST_ASSERT_FALSE(sensor.read());
+    TEST_ASSERT_EQUAL(GuL::Plantower::INCOMPLETE_FRAME, sensor.getLastFailureReason());
+    stream.appendToInput(buffer + frameLength + 3, 1);
+    TEST_ASSERT_TRUE(sensor.read());
+    TEST_ASSERT_EQUAL(11, sensor.getPM1_STD());
+}
+
 void setUp() {}
 void tearDown() {}
 
@@ -231,6 +320,8 @@ int processTests()
     RUN_TEST(test_read_length20_parses_base_pm_only);
     RUN_TEST(test_poll_writes_checksum);
     RUN_TEST(test_checksum_calculation);
+    RUN_TEST(test_failure_states_are_set);
+    RUN_TEST(test_read_proceeds_after_incomplete_frame);
     return UNITY_END();
 }
 

--- a/test/test_pms5003ST/test_pms5003ST.cpp
+++ b/test/test_pms5003ST/test_pms5003ST.cpp
@@ -63,7 +63,7 @@ void test_read_and_parse_frame()
     auto cs = PlantowerTest::publicCalcChecksum(frame, 38);
     frame[38] = (uint8_t)((cs >> 8) & 0xFF);
     frame[39] = (uint8_t)(cs & 0xFF);
-    stream.writeToReadBuffer(frame, sizeof(frame));
+    stream.setInput(frame, sizeof(frame));
 
     TEST_ASSERT_TRUE(sensor.poll());
     TEST_ASSERT_TRUE(sensor.read());

--- a/test/test_pms7003_datasheet/test_pms7003_datasheet.cpp
+++ b/test/test_pms7003_datasheet/test_pms7003_datasheet.cpp
@@ -112,7 +112,7 @@ void test_read_rejects_bad_checksum()
     frame[frameLength + 3] = 0xFF; // Corrupt the checksum
 
     MockUartInterface stream;
-    stream.writeToReadBuffer(frame, sizeof(frame));
+    stream.setInput(frame, sizeof(frame));
     GuL::Plantower sensor(stream);
 
     TEST_ASSERT_FALSE(sensor.read());


### PR DESCRIPTION
If there anything fails or a read did not lead to a valid frame the reason is stored and can get by a getter method.